### PR TITLE
Create IP Int and Store clean records

### DIFF
--- a/database.sql
+++ b/database.sql
@@ -2,5 +2,6 @@ CREATE TABLE dns_records (
 	id bigint unsigned auto_increment primary key,
 	domain varchar(255) not null,
 	type varchar(10) not null,
-	value varchar(255)
+	value varchar(255),
+	ip_dec DECIMAL(39, 0)
 );

--- a/main.go
+++ b/main.go
@@ -90,6 +90,7 @@ func resolve(ch chan string, out chan DnsRecordResult) {
 		dns.TypeNS,
 		dns.TypeMX,
 		dns.TypeSOA,
+		dns.TypeCNAME,
 	}
 
 	for domain := range ch {
@@ -130,7 +131,8 @@ func ip2int(IpAddrString string) *big.Int {
 
 func getRecordString(RecordType uint16, record dns.RR) string {
 
-        recordType := dns.TypeToString[RecordType]
+	// Lets only look at the RR we actually got an answer for
+	recordType := dns.TypeToString[record.Header().Rrtype]
 
         if (recordType == "A") {
                 return record.(*dns.A).A.String()
@@ -150,6 +152,9 @@ func getRecordString(RecordType uint16, record dns.RR) string {
         if (recordType == "SOA") {
               	// Return the mail box of the SOA
             	return record.(*dns.SOA).Mbox
+        }
+	if (recordType == "CNAME") {
+                return record.(*dns.CNAME).Target
         }
 
 	return ""

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ type DnsRecordResult struct {
 	Domain string
 	RecordType uint16
 	Value string
+	IPDec int64
 }
 
 var numDnsGoroutines = flag.Int("dns-goroutines", 10, "Number of DNS goroutines")
@@ -103,6 +104,36 @@ func resolve(ch chan string, out chan DnsRecordResult) {
 			}
 		}
 	}
+}
+
+func getRecord(RecordType uint16, record dns.RR) string {
+
+        recordType := dns.TypeToString[RecordType]
+
+        if (recordType == "A") {
+                return record.(*dns.A).A.String()
+        }
+        if (recordType == "AAAA") {
+                return record.(*dns.AAAA).AAAA.String()
+        }
+        if (recordType == "NS") {
+                return record.(*dns.NS).Ns
+        }
+        if (recordType == "MX") {
+                return record.(*dns.MX).Mx
+        }
+        if (recordType == "TXT") {
+                return record.(*dns.TXT).Txt[0]
+        }
+        if (recordType == "SOA") {
+              	// Return the mail box of the SOA
+            	return record.(*dns.SOA).Mbox
+        }
+        if (recordType == "CNAME") {
+                return record.(*dns.CNAME).Target
+        }
+
+	return ""
 }
 
 func queryDNS(domain string, recordType uint16) []dns.RR {

--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func saveResults(out chan DnsRecordResult) {
 	}
 
 	for result := range out {
-		ins.Bind(result.Domain, dns.TypeToString[result.RecordType], result.Value, result.IPDec)
+		ins.Bind(result.Domain, dns.TypeToString[result.RecordType], result.Value, result.IPDec.String())
 		_, err = ins.Run()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "** ERR:", err)
@@ -115,7 +115,7 @@ func ip2int(IpAddrString string) *big.Int {
 	IpAddr := net.ParseIP(IpAddrString);
 
 	if IpAddr == nil {
-		return nil
+		return big.NewInt(0)
 	}
 
         IpInt := big.NewInt(0)
@@ -125,7 +125,8 @@ func ip2int(IpAddrString string) *big.Int {
         } else {
                 IpInt.SetBytes(IpAddr)
         }
-        return IpInt
+	
+	return IpInt
 }
 
 func getRecordString(RecordType uint16, record dns.RR) string {

--- a/main.go
+++ b/main.go
@@ -91,6 +91,7 @@ func resolve(ch chan string, out chan DnsRecordResult) {
 		dns.TypeMX,
 		dns.TypeSOA,
 		dns.TypeCNAME,
+		dns.TypeTXT,
 	}
 
 	for domain := range ch {

--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ func saveResults(out chan DnsRecordResult) {
 		panic(err)
 	}
 
-	ins, err := db.Prepare("INSERT INTO dns_records (`domain`, `type`, `value`, `ip_dec`) VALUES (?, ?, ?)")
+	ins, err := db.Prepare("INSERT INTO dns_records (`domain`, `type`, `value`, `ip_dec`) VALUES (?, ?, ?, ?)")
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -90,7 +90,6 @@ func resolve(ch chan string, out chan DnsRecordResult) {
 		dns.TypeNS,
 		dns.TypeMX,
 		dns.TypeSOA,
-		dns.TypeCNAME,
 	}
 
 	for domain := range ch {
@@ -151,9 +150,6 @@ func getRecordString(RecordType uint16, record dns.RR) string {
         if (recordType == "SOA") {
               	// Return the mail box of the SOA
             	return record.(*dns.SOA).Mbox
-        }
-        if (recordType == "CNAME") {
-                return record.(*dns.CNAME).Target
         }
 
 	return ""


### PR DESCRIPTION
As title, we are now able to store the integer value of the IP address in DB (both v4 and v6)
This in turn will mean that we can later later look or `A`/`AAAA` records for a prefix easily,

We are also now storing the RR Types that come back, not the ones that we query for

Example: One can query for `A` record but get back a `CNAME`, now we store the result RR rather than what we query
